### PR TITLE
Change gutil to gulp-util

### DIFF
--- a/06Ports/package.json
+++ b/06Ports/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "clear": "0.0.1",
     "gulp": "^3.9.1",
-    "gutil": "^1.6.4",
+    "gulp-util": "^3.0.7",
     "st": "^1.1.0"
   }
 }


### PR DESCRIPTION
Currently the wrong dependency is being installed, and the gulp command will not start. You must have had `gulp-util` installed globally, so that's why there were no errors for you.